### PR TITLE
Fix "Values" card being cut off on narrow displays

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -158,11 +158,10 @@ ol {
 .value {
 	position: relative;
 	overflow: hidden;
-	padding: 40px 40px 65px;
+	padding: 40px 40px 0px;
     border-radius: 10px;
     -webkit-transition: 0.4s;
     transition: 0.4s;
-    height: 145px;
 	width: auto;
 	background-color: #FFEEEE;
 }


### PR DESCRIPTION
On the current site, the "Values" cards are cut off on narrow displays and mobile.
<img width="663" alt="Screen Shot 2020-12-13 at 3 31 18 PM" src="https://user-images.githubusercontent.com/15335110/102027363-55277e00-3d58-11eb-86b2-7fdc52c5ea14.png">

Hopefully this looks better to you :)
<img width="663" alt="Screen Shot 2020-12-13 at 3 31 30 PM" src="https://user-images.githubusercontent.com/15335110/102027373-5d7fb900-3d58-11eb-8ed8-167d0cde178d.png">

